### PR TITLE
Add packer builds for vms and docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
+## Quick Start
+
+```
+docker run -ti tompscanlan/chaperone-ubuntu /bin/bash
+root@b4ba73a52819:/# cd /opt/chaperone/
+```
+
 ## Author Information
 
 Initially created in 2015 by [Tom Hite / VMware](http://www.vmware.com/).

--- a/packer/compile.json
+++ b/packer/compile.json
@@ -1,0 +1,58 @@
+{
+  "variables": {
+    "org_name": "tompscanlan",
+    "app_name": "chaperone",
+    "app_slug": "{{user `org_name`}}/{{user `app_name`}}"
+  },
+  "builders": [
+    {
+      "type": "docker",
+      "image": "ubuntu:14.04",
+      "commit": true
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "scripts": [
+        "packer/setup.sh"
+      ]
+    },
+    {
+      "type": "file",
+      "source": ".",
+      "destination": "/tmp/{{user `app_name`}}"
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "cd /tmp/{{ user `app_name`}}",
+        "ls -al",
+        "repo init -u https://github.com/vmware/chaperone -b master -g chaperone",
+        "repo sync",
+        "tar -zcvf /tmp/{{user `app_name`}}.tar.gz ."
+      ]
+    },
+    {
+      "type": "file",
+      "source": "/tmp/{{user `app_name`}}.tar.gz",
+      "destination": "{{user `app_name`}}.tar.gz",
+      "direction": "download"
+    }
+  ],
+  "post-processors": [
+    [
+      {
+        "type": "artifice",
+        "files": [
+          "{{user `app_name`}}.tar.gz"
+        ]
+      },
+      {
+        "type": "atlas",
+        "artifact": "{{user `org_name`}}/{{user `app_name`}}",
+        "artifact_type": "archive"
+      }
+    ]
+  ]
+}

--- a/packer/packer.json
+++ b/packer/packer.json
@@ -1,0 +1,215 @@
+{
+  "variables": {
+    "atlas_token": "{{env `ATLAS_TOKEN`}}",
+    "version": "0.2.{{env `ATLAS_BUILD_NUMBER`}}",
+    "role": "chaperone",
+    "org": "tompscanlan",
+    "memory": "512",
+    "cpu": "1",
+    "headless": "true",
+    "disk_size": "20000",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ubuntu_iso_url": "http://releases.ubuntu.com/trusty/ubuntu-14.04.3-server-amd64.iso",
+    "ubuntu_iso_checksum": "9e5fecc94b3925bededed0fdca1bd417",
+    "ubuntu_iso_checksum_type": "md5",
+    "docker_repo_username": "{{env `docker_repo_username`}}",
+    "docker_repo_password": "{{env `docker_repo_password`}}",
+    "docker_repo_server": "{{env `docker_repo_server`}}",
+    "docker_repo_email": "{{env `docker_repo_email`}}"
+  },
+  "builders": [
+    {
+      "name": "ubuntu-docker",
+      "type": "docker",
+      "image": "ubuntu",
+      "commit": true
+    },
+    {
+      "name": "ubuntu-virtualbox",
+      "type": "virtualbox-iso",
+      "output_directory": "base-virtualbox",
+      "vm_name": "packer-virtualbox-iso",
+      "boot_command": [
+        "<esc><esc><enter><wait>",
+        "/install/vmlinuz noapic preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg <wait>",
+        "debian-installer=en_US auto locale=en_US kbd-chooser/method=us <wait>",
+        "hostname={{ .Name }} <wait>",
+        "fb=false debconf/frontend=noninteractive <wait>",
+        "keyboard-configuration/modelcode=SKIP keyboard-configuration/layout=USA keyboard-configuration/variant=USA console-setup/ask_detect=false <wait>",
+        "initrd=/install/initrd.gz -- <enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "guest_os_type": "Ubuntu_64",
+      "http_directory": "packer",
+      "iso_checksum": "{{user `ubuntu_iso_checksum`}}",
+      "iso_checksum_type": "{{user `ubuntu_iso_checksum_type`}}",
+      "iso_url": "{{user `ubuntu_iso_url`}}",
+      "ssh_username": "{{user `ssh_username`}}",
+      "ssh_password": "{{user `ssh_password`}}",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "echo 'shutdown -P now' > shutdown.sh; echo 'vagrant'|sudo -S sh 'shutdown.sh'",
+      "headless": "{{user `headless`}}",
+      "disk_size": "{{user `disk_size`}}",
+      "virtualbox_version_file": ".vbox_version",
+      "vboxmanage": [
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "{{user `memory`}}"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "{{user `cpu`}}"
+        ]
+      ]
+    },
+    {
+      "name": "ubuntu-vmware",
+      "type": "vmware-iso",
+      "output_directory": "base-vmware",
+      "boot_command": [
+        "<esc><esc><enter><wait>",
+        "/install/vmlinuz noapic preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg <wait>",
+        "debian-installer=en_US auto locale=en_US kbd-chooser/method=us <wait>",
+        "hostname={{ .Name }} <wait>",
+        "fb=false debconf/frontend=noninteractive <wait>",
+        "keyboard-configuration/modelcode=SKIP keyboard-configuration/layout=USA keyboard-configuration/variant=USA console-setup/ask_detect=false <wait>",
+        "initrd=/install/initrd.gz -- <enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "guest_os_type": "ubuntu-64",
+      "http_directory": "packer",
+      "iso_checksum": "{{user `ubuntu_iso_checksum`}}",
+      "iso_checksum_type": "{{user `ubuntu_iso_checksum_type`}}",
+      "iso_url": "{{user `ubuntu_iso_url`}}",
+      "ssh_username": "{{user `ssh_username`}}",
+      "ssh_password": "{{user `ssh_password`}}",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "echo 'shutdown -P now' > shutdown.sh; echo 'vagrant'|sudo -S sh 'shutdown.sh'",
+      "tools_upload_flavor": "linux",
+      "tools_upload_path": "{{.Flavor}}.iso",
+      "headless": "{{user `headless`}}",
+      "disk_size": "{{user `disk_size`}}",
+      "vmx_data": {
+        "cpuid.coresPerSocket": "1",
+        "memsize": "{{user `memory`}}",
+        "numvcpus": "{{user `cpu`}}",
+        "mks.3denable": false
+      }
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "ls -al ~/"
+      ]
+    },
+    {
+      "type": "shell",
+      "scripts": [
+        "packer/setup.sh"
+      ]
+    }
+  ],
+  "post-processors": [
+    [
+      {
+        "type": "docker-tag",
+        "repository": "{{user `org`}}/{{user `role`}}-ubuntu",
+        "tag": "{{user `version`}}",
+        "force": true,
+        "only": [
+          "ubuntu-docker"
+        ]
+      },
+      {
+        "type": "docker-push",
+        "login": true,
+        "login_email": "{{user `docker_repo_email`}}",
+        "login_username": "{{user `docker_repo_username`}}",
+        "login_password": "{{user `docker_repo_password`}}",
+        "login_server": "{{user `docker_repo_server`}}",
+        "only": [
+          "ubuntu-docker"
+        ]
+      }
+    ],
+    [
+      {
+        "type": "docker-tag",
+        "repository": "{{user `org`}}/{{user `role`}}-ubuntu",
+        "tag": "latest",
+        "force": true,
+        "only": [
+          "ubuntu-docker"
+        ]
+      },
+      {
+        "type": "docker-push",
+        "login": true,
+        "login_email": "{{user `docker_repo_email`}}",
+        "login_username": "{{user `docker_repo_username`}}",
+        "login_password": "{{user `docker_repo_password`}}",
+        "login_server": "{{user `docker_repo_server`}}",
+        "only": [
+          "ubuntu-docker"
+        ]
+      }
+    ],
+    [
+      {
+        "type": "vagrant",
+        "keep_input_artifact": false,
+        "except": [
+          "ubuntu-docker"
+        ]
+      },
+      {
+        "type": "atlas",
+        "only": [
+          "ubuntu-vmware"
+        ],
+        "artifact": "{{user `org`}}/{{user `role`}}-ubuntu",
+        "artifact_type": "vagrant.box",
+        "metadata": {
+          "created_at": "{{timestamp}}",
+          "provider": "vmware_desktop",
+          "version": "{{user `version`}}"
+        }
+      },
+      {
+        "type": "atlas",
+        "only": [
+          "ubuntu-virtualbox"
+        ],
+        "artifact": "{{user `org`}}/{{user `role`}}-ubuntu",
+        "artifact_type": "vagrant.box",
+        "metadata": {
+          "created_at": "{{timestamp}}",
+          "provider": "virtualbox",
+          "version": "{{user `version`}}"
+        }
+      }
+    ]
+  ],
+  "push": {
+    "name": "{{user `org`}}/{{user `role`}}",
+    "base_dir": "../",
+    "exclude": [
+      ".git",
+      "packer_cache/*",
+      ".kitchen/*",
+      ".vagrant/*",
+      "chaperone",
+      ".repo/*",
+      "*.box"
+    ]
+  }
+}

--- a/packer/packer.json
+++ b/packer/packer.json
@@ -1,5 +1,6 @@
 {
   "variables": {
+
     "atlas_token": "{{env `ATLAS_TOKEN`}}",
     "version": "0.2.{{env `ATLAS_BUILD_NUMBER`}}",
     "role": "chaperone",

--- a/packer/preseed.cfg
+++ b/packer/preseed.cfg
@@ -1,0 +1,94 @@
+## Options to set on the command line
+d-i debian-installer/locale string en_US.utf8
+d-i console-setup/ask_detect boolean false
+d-i console-setup/layout string USA
+
+#d-i netcfg/get_hostname string dummy
+d-i netcfg/get_hostname string unassigned-hostname
+d-i netcfg/get_domain string unassigned-domain
+
+# Continue without a default route
+# Not working , specify a dummy in the DHCP
+#d-i netcfg/no_default_route boolean
+
+d-i time/zone string UTC
+d-i clock-setup/utc-auto boolean true
+d-i clock-setup/utc boolean true
+
+d-i kbd-chooser/method select American English
+
+d-i netcfg/wireless_wep string
+
+d-i base-installer/kernel/override-image string linux-server
+#d-i base-installer/kernel/override-image string linux-image-2.6.32-21-generic
+
+# Choices: Dialog, Readline, Gnome, Kde, Editor, Noninteractive
+d-i debconf debconf/frontend select Noninteractive
+
+d-i pkgsel/install-language-support boolean false
+tasksel tasksel/first multiselect standard, ubuntu-server
+
+#d-i partman-auto/method string regular
+d-i partman-auto/method string lvm
+#d-i partman-auto/purge_lvm_from_device boolean true
+
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/device_remove_lvm boolean true
+d-i partman-auto/choose_recipe select atomic
+
+d-i partman/confirm_write_new_label boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+
+#http://ubuntu-virginia.ubuntuforums.org/showthread.php?p=9626883
+#Message: "write the changes to disk and configure lvm preseed"
+#http://serverfault.com/questions/189328/ubuntu-kickstart-installation-using-lvm-waits-for-input
+#preseed partman-lvm/confirm_nooverwrite boolean true
+
+# Write the changes to disks and configure LVM?
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+d-i partman-auto-lvm/guided_size string max
+
+## Default user, we can get away with a recipe to change this
+d-i passwd/root-login boolean false
+d-i passwd/user-fullname string vagrant
+d-i passwd/username string vagrant
+d-i passwd/user-password password vagrant
+d-i passwd/user-password-again password vagrant
+d-i user-setup/encrypt-home boolean false
+d-i user-setup/allow-password-weak boolean true
+
+## minimum is puppet and ssh and ntp
+# Individual additional packages to install
+d-i pkgsel/include string openssh-server ntp
+
+# Whether to upgrade packages after debootstrap.
+# Allowed values: none, safe-upgrade, full-upgrade
+d-i pkgsel/upgrade select full-upgrade
+
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/bootdev  string  /dev/sda
+d-i grub-installer/with_other_os boolean true
+d-i finish-install/reboot_in_progress note
+
+#For the update
+d-i pkgsel/update-policy select none
+
+# debconf-get-selections --install
+#Use mirror
+#d-i apt-setup/use_mirror boolean true
+#d-i mirror/country string manual
+#choose-mirror-bin mirror/protocol string http
+#choose-mirror-bin mirror/http/hostname string 192.168.4.150
+#choose-mirror-bin mirror/http/directory string /ubuntu
+#choose-mirror-bin mirror/suite select maverick
+#d-i debian-installer/allow_unauthenticated string true
+
+choose-mirror-bin mirror/http/proxy string
+
+
+d-i preseed/late_command string \
+  echo "%vagrant ALL=(ALL:ALL) NOPASSWD:ALL" > /target/etc/sudoers.d/vagrant && chmod 0440 /target/etc/sudoers.d/vagrant
+

--- a/packer/setup.sh
+++ b/packer/setup.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+set -x
+
+if grep Ubuntu /etc/lsb-release; then
+	sudo apt-get update -y
+	sudo apt-get upgrade -y
+	sudo apt-get install -y curl virt-what git build-essential python python-dev sshpass
+	sudo apt-get -y autoremove
+	sudo apt-get clean
+	sudo apt-get autoclean
+
+	# setup vagrant and ssh keys
+	if id -u vagrant; then
+		mkdir -p ~vagrant/.ssh
+		chmod 700 ~vagrant/.ssh
+		curl -Lk 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -o ~vagrant/.ssh/authorized_keys
+		chmod 600 ~vagrant/.ssh/authorized_keys
+		chown -R vagrant ~vagrant/.ssh
+	fi
+
+	getent group admin || sudo groupadd -r admin
+	getent passwd vagrant || sudo useradd -m vagrant
+	sudo usermod -a -G admin vagrant
+	sudo cp /etc/sudoers /etc/sudoers.orig
+	sudo sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=admin' /etc/sudoers
+	sudo sed -i -e 's/%admin ALL=(ALL) ALL/%admin ALL=NOPASSWD:ALL/g' /etc/sudoers
+
+	getent passwd vmware || sudo useradd -m vmware
+	sudo usermod -a -G admin vmware
+	echo -e 'VMware1!\nVMware1!' | passwd vmware
+fi
+
+# install easy_install on the way to ansible
+curl https://bootstrap.pypa.io/ez_setup.py | sudo python
+sudo easy_install pip
+sudo pip install ansible
+
+# install repo
+curl https://storage.googleapis.com/git-repo-downloads/repo > /tmp/repo
+sudo mv /tmp/repo /bin/repo
+sudo chmod a+x /bin/repo
+
+[ -d /opt/chaperone ] || sudo mkdir -p /opt/chaperone
+sudo chown root:vagrant /opt/chaperone
+sudo chmod 775 /opt/chaperone
+cd /opt/chaperone
+git config --global user.email "you@example.com"
+git config --global user.name "Your Name"
+repo init -u https://github.com/vmware/chaperone -b master -g chaperone
+repo sync
+
+cd /opt/chaperone/ansible/playbooks/ansible
+ansible-playbook -i inventory ansible.yml


### PR DESCRIPTION
Allows building virtualbox/vmware vagrant boxes and an ubuntu based docker image on Atlas.

The built images have the chaperone repo synced at the time of build, so a 
```
docker run -ti tompscanlan/chaperone-ubuntu /bin/bash
root@b4ba73a52819:/# cd /opt/chaperone/
```
has the latest tree available.  you can use this from a development machine's copy of the repo via:

```
docker run -ti -v path-to-local-repo:/opt/chaperone tompscanlan/chaperone-ubuntu /bin/bash
root@b4ba73a52819:/# cd /opt/chaperone/
```

If it's acceptable, we can discuss building under a chaperone account at atlas. 
